### PR TITLE
Add: [jp] Warudo Pro

### DIFF
--- a/i18n/jp/docusaurus-plugin-content-docs/current/pro.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/pro.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 11
+---
+
+# Warudo Pro
+
+## Warudo Proとは？
+
+Warudo Proは、法人ユーザー向けに提供しているWarudoのバージョンです。
+Warudo Proでは、Steam版の全機能に加え、Universal Render Pipeline（URP）のサポート、[NiloToonレンダリング](https://github.com/ColinLeung-NiloCat/UnityURPToonLitShaderExample#nilotoonurp-users-creations-public-media-not-nda-contents)、[Autodesk MotionBuilder、および光学式モーションキャプチャシステム （VICON、OptiTrack など）](mocap/motionbuilder) のサポートが追加されています。
+
+Warudo Proの[Stage Directorモード](assets/director)を活用して映画のようなカメラ制御を行うことで、Warudo Proのユーザーは業界をリードする3D VTuberライブパフォーマンスを実現できます。
+
+Warudo Proの[最近の導入事例はこちら](https://twitter.com/hakuyalabs/status/1713191982162727037)でご覧いただけます。
+
+詳細については、[info@warudo.app](mailto:info@warudo.app)までお問い合わせください。
+
+## 私は個人VTuberです。Warudo Proを購入できますか？
+
+できます！以下の条件を満たす場合に限り、個人VTuber向けにWarudo Proを特別価格でご提供いたします。
+
+- あなたがVTuber IP（知的財産権）、およびSNS/ライブ配信プラットフォームのアカウント所有権を有していること
+- 配信活動が個人的な行為であり、第三者（VTuber事務所や代理店など）との契約に含まれないこと（Twitch、YouTubeなどライブ配信プラットフォームとの直接契約を除く）
+
+<AuthorBar authors={{
+  creators: [
+    {name: 'HakuyaTira', github: 'TigerHix'},
+  ],
+  translators: [
+    {name: 'unsoluble_sugar', github: 'unsolublesugar'},
+  ],
+}} />

--- a/i18n/jp/docusaurus-plugin-content-docs/current/pro.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/pro.md
@@ -7,9 +7,8 @@ sidebar_position: 11
 ## Warudo Proとは？
 
 Warudo Proは、法人ユーザー向けに提供しているWarudoのバージョンです。
-Warudo Proでは、Steam版の全機能に加え、Universal Render Pipeline（URP）のサポート、[NiloToonレンダリング](https://github.com/ColinLeung-NiloCat/UnityURPToonLitShaderExample#nilotoonurp-users-creations-public-media-not-nda-contents)、[Autodesk MotionBuilder、および光学式モーションキャプチャシステム （VICON、OptiTrack など）](mocap/motionbuilder) のサポートが追加されています。
 
-Warudo Proの[Stage Directorモード](assets/director)を活用して映画のようなカメラ制御を行うことで、Warudo Proのユーザーは業界をリードする3D VTuberライブパフォーマンスを実現できます。
+Warudo Proでは、Steam版の全機能に加え、Universal Render Pipeline（URP）のサポート、[NiloToonレンダリング](https://github.com/ColinLeung-NiloCat/UnityURPToonLitShaderExample#nilotoonurp-users-creations-public-media-not-nda-contents)、[Autodesk MotionBuilder、および光学式モーションキャプチャシステム （VICON、OptiTrack など）](mocap/motionbuilder) のサポートが追加されています。Warudo Proの[Stage Directorモード](assets/director)を活用して映画のようなカメラ制御を行うことで、Warudo Proのユーザーは業界をリードする3D VTuberライブパフォーマンスを実現できます。
 
 Warudo Proの[最近の導入事例はこちら](https://twitter.com/hakuyalabs/status/1713191982162727037)でご覧いただけます。
 

--- a/i18n/jp/docusaurus-plugin-content-docs/current/pro.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/pro.md
@@ -26,6 +26,6 @@ Warudo Proの[最近の導入事例はこちら](https://twitter.com/hakuyalabs/
     {name: 'HakuyaTira', github: 'TigerHix'},
   ],
   translators: [
-    {name: 'unsoluble_sugar', github: 'unsolublesugar'},
+    {name: '星影月夜', github: 'unsolublesugar'},
   ],
 }} />


### PR DESCRIPTION
Added Japanese translation of Warudo Pro
- Add jp `/current/pro.md`
- Relate: 
    - #15
    - #13

![localhost_3012_jp_docs_pro (1)](https://github.com/HakuyaLabs/warudo-docs/assets/8685879/68db958c-5b2b-4570-816f-bba411715506)
