### PR TITLE
update: [jp] search-related functions

### DIFF
--- a/i18n/jp/code.json
+++ b/i18n/jp/code.json
@@ -267,38 +267,38 @@
     "description": "The ARIA label and title attribute for expand button of doc sidebar"
   },
   "theme.SearchPage.existingResultsTitle": {
-    "message": "Search results for \"{query}\"",
+    "message": "\"{query}\" の検索結果",
     "description": "The search page title for non-empty query"
   },
   "theme.SearchPage.emptyResultsTitle": {
-    "message": "Search the documentation",
+    "message": "ドキュメントを検索する",
     "description": "The search page title for empty query"
   },
   "theme.SearchPage.searchContext.everywhere": {
     "message": "everywhere"
   },
   "theme.SearchPage.documentsFound.plurals": {
-    "message": "1 document found|{count} documents found",
+    "message": "{count} 件のドキュメントが見つかりました",
     "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.SearchPage.noResultsText": {
-    "message": "No documents were found",
+    "message": "ドキュメントが見つかりませんでした。",
     "description": "The paragraph for empty search result"
   },
   "theme.SearchBar.noResultsText": {
-    "message": "No results"
+    "message": "一致するドキュメントが見つかりませんでした。"
   },
   "theme.SearchBar.seeAllOutsideContext": {
     "message": "See results outside {context}"
   },
   "theme.SearchBar.searchInContext": {
-    "message": "See all results in {context}"
+    "message": "{context} の検索結果をすべて見る"
   },
   "theme.SearchBar.seeAll": {
-    "message": "See all results"
+    "message": "検索結果をすべて見る"
   },
   "theme.SearchBar.label": {
-    "message": "Search",
+    "message": "検索",
     "description": "The ARIA label and placeholder for search button"
   },
   "theme.ErrorPageContent.tryAgain": {

--- a/i18n/jp/docusaurus-plugin-content-docs/current/misc/handbook-contribution.md
+++ b/i18n/jp/docusaurus-plugin-content-docs/current/misc/handbook-contribution.md
@@ -125,6 +125,11 @@ Warudo Handbook左側のナビゲーションバー構造も英語版ファイ�
    **`yarn start:jp`** 日本語版を起動  
    **`yarn start:all`** 異なるポートで複数の言語環境を起動
 
+:::caution
+
+ローカル環境での開発中（`yarn start`での起動）は検索が機能しません。検索関連の動作を確認する際は、 `yarn build` でドキュメントをビルド後、 **`yarn serve`** で起動してください（参考: [docusaurus-search-local](https://github.com/cmfcmf/docusaurus-search-local?tab=readme-ov-file#usage)）  
+:::
+
 これで準備が整い、ローカルマシン上で実行されるWarudo Handbookがブラウザに表示されるはずです。ドキュメント内容を変更して保存すると、ブラウザが自動的にページを更新します。  
 ドキュメント内容を編集して試してみてください！
 


### PR DESCRIPTION
## Summary

Update Japanese translation of search-related functions.

![2024-07-09_11h48_05](https://github.com/HakuyaLabs/warudo-docs/assets/8685879/9dd2297d-e67b-44ac-8bf4-e1aad7da1aea)
![2024-07-09_11h51_31](https://github.com/HakuyaLabs/warudo-docs/assets/8685879/edad674a-faf4-4df7-9fbf-db70156ce3bc)

Added description of `yarn serve` command to run local searches on the Document Contribution page.

![2024-07-09_12h17_30](https://github.com/HakuyaLabs/warudo-docs/assets/8685879/1ffe67b4-cfb7-407b-a355-14e2add9f9a4)

## Relate
- #13 