### PR TITLE
Correction of the name "OSC/VMC Protocol"

### DIFF
--- a/docs/mocap/vmc.md
+++ b/docs/mocap/vmc.md
@@ -24,7 +24,7 @@ Make sure you have connected your VR trackers to SteamVR. Then, open VirtualMoti
 
 The following example demonstrates how to apply VMC data to the character using [VSeeFace](https://www.vseeface.icu/). Other software that supports VMC can be configured in a similar manner.
 
-In **General settings**, make sure **OSC/VMC Protocol → Send datawith OSC/VMC protocol** is checked. The default port 39539 is also the default port that Warudo's VMC receiver uses.
+In **General settings**, make sure **VMC Protocol → Send datawith VMC protocol** is checked. The default port 39539 is also the default port that Warudo's VMC receiver uses.
 
 ![](/doc-img/zh-vmc-1.webp)
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/mocap/vmc.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/mocap/vmc.md
@@ -24,7 +24,7 @@ VR 트래커를 SteamVR에 연결했는지 확인하세요. 그런 다음, Virtu
 
 다음 예시는 [VSeeFace](https://www.vseeface.icu/)를 사용하여 VMC 데이터를 캐릭터에 적용하는 방법을 보여줘요. VMC를 지원하는 다른 소프트웨어도 유사한 방식으로 구성할 수 있어요.
 
-**General settings**에서 **OSC/VMC Protocol → Send datawith OSC/VMC protocol**이 체크되어 있는지 확인하세요. 기본 포트 39539는 Warudo의 VMC 수신기가 사용하는 기본 포트이기도 해요.
+**General settings**에서 **VMC Protocol → Send datawith VMC protocol**이 체크되어 있는지 확인하세요. 기본 포트 39539는 Warudo의 VMC 수신기가 사용하는 기본 포트이기도 해요.
 
 ![](/doc-img/zh-vmc-1.webp)
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/mocap/vmc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/mocap/vmc.md
@@ -10,7 +10,7 @@ sidebar_position: 80
 
 以下使用 [VSeeFace ](https://www.vseeface.icu/)为例，演示怎样将 VMC 数据应用到角色上。其他支持 VMC 的软件可以通过类似方法配置。
 
-右上角点击设置 → 整体设置，勾选「OSC/VMC协议」->「发送配合OSC/VMC协议的数据」。默认 IP 是本机 IP；默认端口 39539 也是 Warudo 的 VMC 接收器默认接收的端口，所以如果你想将 VSeeFace 的动捕数据发送到在同一台电脑运行的 Warudo，那么这里的设置无需更改。
+右上角点击设置 → 整体设置，勾选「VMC协议」->「发送配合VMC协议的数据」。默认 IP 是本机 IP；默认端口 39539 也是 Warudo 的 VMC 接收器默认接收的端口，所以如果你想将 VSeeFace 的动捕数据发送到在同一台电脑运行的 Warudo，那么这里的设置无需更改。
 
 ![](/doc-img/zh-vmc-1.webp)
 


### PR DESCRIPTION
## Summary

The name "OSC/VMC Protocol" used in VSeeFace does not seem to be the term intended by the authors of VirtualMotionCapture.

source: https://x.com/sh_akira/status/1666049283957878784

Although the correction has not yet been reflected in the VSeeFace application, I've replaced the text in the Warudo documentation to reflect the author's intent, as I don't want to further spread the incorrect name.

## Relate
I'll also write the Japanese documentation in the form of "VMC Protocol" instead of "OSC/VMC Protocol".
#52