### PR TITLE
Fix: Broken link for VRM BlendShapeClips

### DIFF
--- a/docs/assets/character.md
+++ b/docs/assets/character.md
@@ -29,7 +29,7 @@ To set up motion capture for your character, please refer to the [Motion Capture
 
 ## Expressions {#expressions}
 
-Expressions are a way to control the character's facial expressions on top of your face tracking. The character asset supports both VRM expressions (also known as [VRM BlendShapeClips](https://vrm.dev/en/univrm/blendshape/univrm\_blendshape.html)) and custom expressions.
+Expressions are a way to control the character's facial expressions on top of your face tracking. The character asset supports both VRM expressions (also known as [VRM BlendShapeClips](https://vrm.dev/en/univrm/blendshape/univrm_blendshape/)) and custom expressions.
 
 During onboarding, Warudo will automatically import all of the VRM expressions in your character, and generate a blueprint to add hotkeys for them. You can also import VRM expressions manually by clicking **Import VRM Expressions**, and generate a blueprint for key binding by clicking **Generate Key Binding Blueprint**.
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/assets/character.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/assets/character.md
@@ -29,7 +29,7 @@ sidebar_position: 10
 
 ## 표현 {#expressions}
 
-표현은 얼굴 추적 외에도 캐릭터의 얼굴 표정을 제어하는 방법이에요. 캐릭터 asset은 VRM 표현 ([VRM BlendShapeClips](https://vrm.dev/en/univrm/blendshape/univrm\_blendshape.html)로도 알려져 있음)과 사용자 정의 표현 모두를 지원해요.
+표현은 얼굴 추적 외에도 캐릭터의 얼굴 표정을 제어하는 방법이에요. 캐릭터 asset은 VRM 표현 ([VRM BlendShapeClips](https://vrm.dev/en/univrm/blendshape/univrm_blendshape/)로도 알려져 있음)과 사용자 정의 표현 모두를 지원해요.
 
 온보딩 중에 Warudo는 캐릭터의 모든 VRM 표현을 자동으로 가져오고, 해당 표현에 단축키를 추가하는 blueprint를 생성해요. 또한, **Import VRM Expressions**를 클릭하여 VRM 표현을 수동으로 가져오고,  **Generate Key Binding Blueprint**를 클릭하여 키 바인딩을 위한 blueprint를 생성할 수도 있어요.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/assets/character.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/assets/character.md
@@ -45,9 +45,9 @@ To set up motion capture for your character, please refer to the [Motion Capture
 
 ## 表情 {#expressions}
 
-「表情」可以在面部捕捉的基础上进一步控制角色的面部表情。角色资源支持 VRM 表情（又名 [VRM BlendShapeClips](https://vrm.dev/en/univrm/blendshape/univrm\_blendshape.html)）以及自定义表情。
+「表情」可以在面部捕捉的基础上进一步控制角色的面部表情。角色资源支持 VRM 表情（又名 [VRM BlendShapeClips](https://vrm.dev/en/univrm/blendshape/univrm_blendshape/)）以及自定义表情。
 
-Expressions are a way to control the character's facial expressions on top of your face tracking. The character asset supports both VRM expressions (also known as [VRM BlendShapeClips](https://vrm.dev/en/univrm/blendshape/univrm\_blendshape.html)) and custom expressions.
+Expressions are a way to control the character's facial expressions on top of your face tracking. The character asset supports both VRM expressions (also known as [VRM BlendShapeClips](https://vrm.dev/en/univrm/blendshape/univrm_blendshape/)) and custom expressions.
 
 在新手向导中，Warudo 会自动导入角色的所有 VRM 表情，并生成对应热键的蓝图。你也可以点击**导入 VRM 表情**和**生成按键绑定蓝图**这两个按钮来手动完成对应的操作。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/assets/character/blendshape-expression.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/assets/character/blendshape-expression.md
@@ -5,7 +5,7 @@ sidebar_position: 10
 
 # 表情
 
-* 导入 VRM 表情：如果模型是 VRM 格式，导入模型内置的所有 VRM [BlendShapeClip ](https://vrm.dev/en/univrm/blendshape/univrm\_blendshape.html)作为表情。
+* 导入 VRM 表情：如果模型是 VRM 格式，导入模型内置的所有 VRM [BlendShapeClip ](https://vrm.dev/en/univrm/blendshape/univrm_blendshape/)作为表情。
 * 生成按键绑定蓝图：根据当前配置好的表情，生成按键绑定蓝图。
 
 :::info
@@ -57,7 +57,7 @@ Alt+Z, Alt+X, Alt+C... Alt+/
           * 最小值：当此表情为激活状态时，受约束 BlendShape 的值不能小于此值。
           * 最大值：当此表情为激活状态时，受约束 BlendShape 的值不能大于此值。
       * 目标材质属性：
-        * 目前该选项仅为兼容 VRM BlendShapeClip 的 [MaterialValueBinding](https://vrm.dev/en/univrm/blendshape/univrm\_blendshape.html#id3)（用来修改模型某材质的属性，比如将衣服材质变透明实现换衣效果）。
+        * 目前该选项仅为兼容 VRM BlendShapeClip 的 [MaterialValueBinding](https://vrm.dev/en/univrm/blendshape/univrm_blendshape/#id3)（用来修改模型某材质的属性，比如将衣服材质变透明实现换衣效果）。
 * 默认 BlendShape 列表：模型默认设置的 BlendShape（除非被动捕数据覆盖）。
   * 列表元素：
     * 目标蒙皮网格：BlendShape 位于的蒙皮网格（Skinned Mesh）。


### PR DESCRIPTION
VRM BlendShapeClips link URL was incorrect and has been corrected.
Correct link: https://vrm.dev/en/univrm/blendshape/univrm_blendshape/