### PR TITLE
Fix runtime error in AuthorBar by using public useDoc API

### DIFF
--- a/src/components/AuthorBar/AuthorBar.tsx
+++ b/src/components/AuthorBar/AuthorBar.tsx
@@ -1,5 +1,5 @@
 import Translate from '@docusaurus/Translate';
-import { useDoc } from '@docusaurus/theme-common/internal';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
 import { IoCreateOutline } from 'react-icons/io5';


### PR DESCRIPTION
## Summary

This pull request fixes a runtime error that occurs when launching the development server due to the use of an outdated internal API in `AuthorBar.tsx`.

![スクリーンショット 2025-05-08 190755](https://github.com/user-attachments/assets/448af130-3799-4b69-abcb-3bd3d36d206e)


## Background

The original code imports `useDoc` from the internal package:

```ts
import { useDoc } from '@docusaurus/theme-common/internal';
```

This causes a runtime error:

```
TypeError: (0 , _docusaurus_theme_common_internal__WEBPACK_IMPORTED_MODULE_4__.useDoc) is not a function
```

This happens because `useDoc` has been removed from the internal module in newer versions of Docusaurus.

## Changes

Replaced the import with the officially supported public API:

```ts
import { useDoc } from '@docusaurus/plugin-content-docs/client';
```

## Notes

- Please feel free to suggest any changes or improvements if needed.
- Thank you for maintaining this valuable documentation project!
