### PR TITLE
Fix JSX-related type errors by updating tsconfig and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
     "react-twitter-embed": "^4.0.4",
     "sass": "^1.68.0"
   },
+  "resolutions": {
+    "@types/react": "18.2.45",
+    "**/@types/react": "18.2.45"
+  },
   "devDependencies": {
     "@docusaurus/tsconfig": "^3.4.0",
     "typescript": "^5.4.5"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "types": ["docusaurus-plugin-sass"],
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
## Summary

This pull request updates both `tsconfig.json` and `package.json` to resolve JSX-related type errors and ensure full compatibility with React 18, which is used by Docusaurus v3.

## Background

When using JSX components like `Translate` in TypeScript files, a type error may occur due to mismatched or missing `ReactNode` definitions. This is typically caused by:

- Multiple versions of `@types/react` being pulled into the project (e.g., one from the root and another from `@docusaurus/types`)
- Missing or incorrect `jsx` compiler option in `tsconfig.json`

## Changes

- Added `"jsx": "react-jsx"` to `tsconfig.json` to explicitly support React 17+ JSX transformation
- Added a `resolutions` field to `package.json` to ensure that `@types/react` is unified across all dependencies

## Notes

- These changes improve editor experience and prevent runtime or type-checking issues
- The `resolutions` field works with Yarn (as this project uses `yarn@4`)
- After this change, run `yarn install` to apply updated resolutions
- Thank you for maintaining this valuable project!

## Related Pull Requests

This change was prompted by a previous fix that replaced an internal `useDoc` import with the public API. After that change, JSX-related type errors surfaced due to React type mismatches.

Related PR: #98