### PR TITLE
docs(ko): Sync mocap overview with current English structure

### DIFF
--- a/i18n/ko/docusaurus-plugin-content-docs/current/mocap/overview.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/mocap/overview.md
@@ -25,9 +25,10 @@ sidebar_position: 10
 
 [Warudo Pro](../pro.md)는 다음 모션 캡처 시스템도 지원해요:
 
-* [Autodesk MotionBuilder](./motionbuilder)와 호환되는 모든 광학 추적 시스템, e.g., [Vicon](https://www.vicon.com/), [OptiTrack](https://optitrack.com/)
+* [Vicon Shogun](./vicon)
 * [OptiTrack Motive](./optitrack)
 * [Chingmu Avatar](./chingmu)
+* [Autodesk MotionBuilder](./motionbuilder)와 호환되는 모든 추적 시스템
 
 ## 어떤 모션 캡처 시스템을 사용해야 하나요?
 
@@ -89,5 +90,6 @@ Warudo에서 모션 캡처를 설정하는 두 가지 방법이 있어요. 첫 �
   ],
   translators: [
     {name: 'Willycho', github: 'Willycho'},
+    {name: 'Onev', github: 'OneVth'},
   ],
 }} />


### PR DESCRIPTION
## Summary

Sync the Korean mocap overview with the current English structure.

- Restore standalone `[Vicon Shogun](./vicon)` bullet
- Reorder MotionBuilder bullet to match EN
- Add translator credit to `<AuthorBar>`

## Context

EN source updated 6 months ago (commit `9d7880e`, `update vicon`) split 
Vicon Shogun into a standalone bullet. KO last edited 2 years ago and 
predates this change. The same gap exists in zh/jp/es locales — this 
PR addresses Korean only.

## Note

`mocap/vicon.md` is not yet translated to Korean; the restored link 
falls back to the English page. Would it be okay if I translated it as 
a follow-up PR?