### PR TITLE
Add Korean translations for 6 remaining untranslated pages

### DIFF
--- a/i18n/ko/docusaurus-plugin-content-docs/current/blueprints/miscellaneous/streamdeck-integration.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/blueprints/miscellaneous/streamdeck-integration.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 30
+version: 2026-01-23
+---
+
+# Stream Deck 연동
+
+**Stream Deck 연동**을 사용하면 Stream Deck에서 직접 Warudo의 트리거, 토글, 메시지 전송을 할 수 있어요.
+
+![](/doc-img/streamdeck-integration-0.png)
+
+---
+
+## 준비
+
+Warudo에서 Stream Deck 연동을 사용하려면, [Stream Deck](https://www.elgato.com/p/stream-deck) 장치가 있어야 하고 [Stream Deck 앱](https://www.elgato.com/s/stream-deck-app)이 올바르게 설치되어 있어야 해요.
+
+다음으로, Stream Deck 마켓플레이스에서 Warudo 플러그인을 설치해야 해요: [Warudo | Elgato Marketplace](https://marketplace.elgato.com/product/warudo-d443ffb3-0b14-40d8-aa95-cdac4688328d)
+
+## 사용법
+
+Warudo는 Stream Deck과 관련된 세 가지 노드를 제공해요:
+
+- **On Stream Deck Trigger**
+- **On Stream Deck Toggle**
+- **On Stream Deck Message**
+
+이 노드들은 Stream Deck 앱의 Warudo 플러그인에 있는 세 가지 액션에 대응해요:
+
+- **Trigger**
+- **Toggle**
+- **Message**
+
+노드와 액션을 연결하려면 다음 단계를 따라주세요:
+
+1. Warudo에서 **On Stream Deck ...** 노드를 추가하세요.
+2. 노드의 **Receiver Name** 포트에 이름을 입력하세요.
+![](/doc-img/streamdeck-integration-4.png)
+3. Stream Deck 앱에서 **노드 유형과 일치하는** 액션을 추가하세요.
+4. 액션의 **Receiver Name** 드롭다운에서 노드의 **Receiver Name** 포트에 입력한 문자열이 표시될 거예요.
+![](/doc-img/streamdeck-integration-5.png)
+5. 이를 선택하세요. 이제 Stream Deck에서 해당 액션을 누르면 Warudo의 해당 노드가 트리거될 거예요!
+![](/doc-img/streamdeck-integration-6.png)
+
+:::caution
+드롭다운에 옵션이 표시되지 않고, 노드 유형과 액션 유형이 일치하는 것을 확인했다면, Stream Deck과 Warudo 간의 연결이 올바르게 설정되지 않았을 수 있어요.
+두 애플리케이션을 모두 재시작하거나, 컴퓨터를 재부팅하거나, 최신 버전으로 업데이트해 보세요. 이 방법으로 문제가 해결될 수 있어요.
+:::
+
+세 가지 노드/액션 유형의 차이점은 아래에서 설명할게요.
+
+### Trigger
+
+**Trigger** 액션을 활성화하면, 연결된 노드의 "**Exit**" 포트가 활성화돼요.
+
+### Toggle
+
+⚪ *회색* 아이콘의 **Toggle** 액션을 활성화하면, 연결된 노드의 "**If Yes**" 포트가 활성화되고 🟣 *보라색*으로 변해요.
+
+🟣 *보라색* 아이콘의 **Toggle** 액션을 활성화하면, 연결된 노드의 "**If No**" 포트가 활성화되고 ⚪ *회색*으로 변해요.
+
+### Message
+
+**Message** 액션을 활성화하면, "**Message**" 포트의 값이 변경되고 연결된 노드의 "**Exit**" 포트가 활성화돼요.
+
+## 예시
+
+### 표정 전환
+
+![](/doc-img/streamdeck-integration-1.png)
+
+### 인터랙티브 효과
+
+![](/doc-img/streamdeck-integration-2.png)
+
+### 카메라 및 액세서리
+
+![](/doc-img/streamdeck-integration-3.png)
+
+<AuthorBar authors={{
+  creators: [
+    {name: 'Hane', github: 'hanekit'},
+  ],
+  translators: [
+    {name: 'Puri', github: 'Puri12'},
+  ],
+}} />

--- a/i18n/ko/docusaurus-plugin-content-docs/current/blueprints/miscellaneous/transition-easing.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/blueprints/miscellaneous/transition-easing.md
@@ -1,0 +1,19 @@
+---
+sidebar_position: 10
+version: 2026-01-09
+---
+
+# 트랜지션 이징
+
+**트랜지션 이징** 인자는 강력한 "Set Asset Property" 노드를 비롯한 여러 blueprint 노드에서 사용돼요.
+
+각 옵션의 효과에 대한 자세한 설명은 다음을 참고해 주세요: [Easing Functions Cheat Sheet](https://easings.net/).
+
+<AuthorBar authors={{
+  creators: [
+    {name: 'Hane', github: 'hanekit'},
+  ],
+  translators: [
+    {name: 'Puri', github: 'Puri12'},
+  ],
+}} />

--- a/i18n/ko/docusaurus-plugin-content-docs/current/blueprints/templates/pen-display-hand-sync.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/blueprints/templates/pen-display-hand-sync.md
@@ -1,0 +1,195 @@
+---
+sidebar_position: 3
+version: 2024-08-28
+---
+
+# 펜 디스플레이 손 동기화
+## 소개
+
+![](/doc-img/pen-display-hand-sync-9.png)
+
+이 페이지는 **그림 그리기나 디자인 작업을 위한 라이브 방송을 직접 구성**하는 데 도움이 되는 예제 씬을 제공해요.
+**펜을 잡고** 있는 상태에서 Warudo 세계의 **스크린 에셋 안에서 커서를 완벽하게 따라가도록** 할 수 있어요!
+
+<div style={{width: '100%'}} className="video-box">
+<video controls loop src="/doc-img/pen-display-hand-sync-10.mp4" />
+</div>
+<p class="img-desc">쇼케이스!</p>
+
+## 튜토리얼
+
+###  1단계 - 준비
+
+1. 먼저, 다음 튜토리얼을 진행하기 위해 Steam 워크샵에서 아래 항목들을 구독해야 해요:
+
+	| 항목        | Steam 워크샵 URL                                                                         |
+	|:----------- |:------------------------------------------------------------------------------------------ |
+	| 환경 | [🔗 Loft Apartment](https://steamcommunity.com/sharedfiles/filedetails/?id=3033191267)        |
+	| 캐릭터   | [🔗 VRoid Avatar Sample A](https://steamcommunity.com/sharedfiles/filedetails/?id=3003820352) |
+	| 소품 1      | [🔗 Square Grid](https://steamcommunity.com/sharedfiles/filedetails/?id=3295273541)           |
+	| 소품 2      | [🔗 Drawing Tablet Set](https://steamcommunity.com/sharedfiles/filedetails/?id=3146409616)    |
+	| 노드        | [🔗 Mouse Position Nodes](https://steamcommunity.com/sharedfiles/filedetails/?id=3159188937)  |
+
+2. 다음으로, 아래 파일을 다운로드하여 `<WARUDO_DATA_FOLDER>\Scenes` 폴더에 넣어주세요:
+
+<ol style={{ "list-style-type": "none" }}><li>
+<ul><li>
+    <a
+    target="_blank"
+    href="/scenes/Warudo_PenDisplay_SampleScene_v20240828.json"
+    download="Warudo_PenDisplay_SampleScene_v20240828.json">
+      🔗 Warudo_PenDisplay_SampleScene_v20240828.json
+    </a> 
+</li></ul>
+</li></ol>
+
+3. 그런 다음, Warudo에서 `Open scene` 옵션을 통해 다운로드한 씬을 열 수 있어요.
+
+:::warning[Warudo Pro 사용자의 경우]
+
+이 튜토리얼을 따르려면 URP (Nilotoon)에서 BiRP로 전환해야 해요.
+설정이 완료된 후 다시 전환하고, 환경과 캐릭터를 URP 버전으로 교체할 수 있어요.
+
+:::
+
+### 2단계 - 디스플레이 할당 (멀티 디스플레이 사용자용)
+
+1. Warudo 메인 창을 표시할 모니터를 결정하세요.
+(이를 **모니터 A**라고 부를게요)
+2. Warudo에서 표시할 모니터를 결정하세요.
+(이를 **모니터 B**라고 부를게요)
+
+모니터 A = 모니터 B인 경우, **3단계**로 바로 건너뛸 수 있어요. 그렇지 않다면:
+
+3. ✨ `Mouse Position Relative To Screen` 노드에서 `Output Offset X/Y` 값을 변경하여 마우스가 모니터 B의 **좌측 상단 모서리**에 있을 때 `Output`이 `(0,0)`이 되도록 해주세요.
+
+	![](/doc-img/pen-display-hand-sync-1.png)
+
+:::tip[오프셋 값을 결정하는 방법]
+
+1. 마우스를 모니터 B의 **좌측 상단 모서리**로 이동하세요.
+2. 현재 `Output`의 ❗ **반대 값** ❗을 `Output Offset X/Y`에 입력하세요.
+**예시:** 마우스가 좌측 상단 모서리에 있을 때 Output이 (1920, -1080)이라면, 다음과 같이 입력해야 해요:
+`Output Offset X` = `-1920`
+`Output Offset Y` = `+1080`
+3. ✨ 단계를 다시 확인하세요.
+
+:::
+
+:::warning
+
+모니터 A 또는 B의 선택을 변경할 때마다 오프셋 값을 다시 조정해야 해요.
+
+:::
+
+### 3단계 - 디스플레이 해상도 입력
+
+`Decompose Vector2` 노드에 **모니터 B**의 해상도(픽셀 단위)를 입력하세요.
+
+![](/doc-img/pen-display-hand-sync-2.png)
+
+:::note[일반적인 16:9 해상도]
+
+| 크기  |  X   |  Y   |
+|:-----:|:----:|:----:|
+| 1080p | 1920 | 1080 |
+|  2K   | 2560 | 1440 |
+|  4K   | 3840 | 2160 |
+|   ⋯   |  ⋯   |  ⋯   |
+
+:::
+
+### 4단계 - 디스플레이 선택
+
+`Prop - Drawing Screen`의 `Content` - `Display`에서 **모니터 B에 해당하는 디스플레이**를 선택하세요.
+
+![](/doc-img/pen-display-hand-sync-3.png)
+
+### 5단계 - (선택 사항) 에셋 커스터마이징
+
+:::info
+
+**처음 시도할 때는 이 단계를 건너뛰는 것을 권장해요.**
+
+:::
+
+**Onboarding Assistant**를 사용하여 자신만의 캐릭터, 환경, 모션 캡처를 설정할 수 있어요.
+
+캐릭터와 스크린의 위치도 커스터마이징할 수 있어요.
+
+캐릭터에 따라 **`Anchor - Right Hand IK`**의 **`Transform`** - **`Position`** 값을 조정하여 캐릭터가 펜을 더 잘 잡도록 해야 할 수 있어요.
+
+:::warning
+
+모션 캡처 설정에서 **`Finger Movements` 진자 물리를 비활성화해야 해요!**
+
+![](/doc-img/pen-display-hand-sync-6.png)
+
+- 다른 신체 관련 진자 물리(`Arm Movements`나 `Body Lean` 등)도 끄는 것을 권장해요.
+
+:::
+
+### 6단계 - 매핑 보정
+
+`Prop - Calibration Border`의 `Scale`에서 **`X`**와 **`Y`** 값을 각각 조정하세요.
+스크린이 빨간색 상자의 **안쪽 가장자리**에 최대한 완벽하게 맞도록 해주세요.
+
+:::note
+
+매번 스케일을 조정하기 전에 🔗 **`Uniform Scaling`**을 해제해야 해요.
+
+:::
+
+![](/doc-img/pen-display-hand-sync-4.png)
+
+### 7단계 - 보정 경계선 숨기기
+
+마지막으로, **`Prop - Calibration Border`** 에셋의 `Enabled` 옵션을 `No`로 전환하여 숨길 수 있어요.
+
+![](/doc-img/pen-display-hand-sync-5.png)
+
+:::warning
+
+`Prop - Calibration Border`를 삭제하지 마세요. 삭제하면 다음에 보정을 할 수 없게 돼요.
+
+:::
+
+## 참고 사항
+
+- 모션 캡처 에셋에서 **`Mirrored Tracking`** 또는 **`Invert Hands`**를 변경하여 원하는 추적 방식을 선택해야 할 수 있어요.
+
+- 모니터 A 또는 모니터 B의 선택을 변경하려면, 2~6단계를 반복해야 해요.
+
+- **`Prop - Drawing Screen`**의 두께를 조정하거나, **`Prop - Tablet`**을 활성화하고 스케일을 조정하여 현실감을 더 높일 수 있어요.
+
+## 알려진 문제
+
+### 손-펜 클리핑
+
+이 blueprint의 최우선 순위가 **펜 끝을 커서에 맞추는 것**이기 때문에, 손 IK의 구현 원리상 손이 스크린 중심에서 너무 멀어지면 펜이 손에 완벽하게 맞지 않을 수 있어요.
+
+따라서 스크린의 스케일을 너무 크게 조정하지 않는 것을 권장해요.
+
+
+![](/doc-img/pen-display-hand-sync-7.png)
+
+펜을 손가락 본에 바인딩하면 이 문제를 피할 수 있지만, 펜이 커서를 완벽하게 따라가지 못하게 돼요. 이 방식은 펜 디스플레이보다는 펜 태블릿에 더 적합해요.
+(현재 이 씬은 이 모드를 지원하지 않아요)
+
+### 디스플레이 사라짐
+
+Warudo 메인 창의 우측 상단 닫기 버튼을 클릭하고 프로그램을 완전히 종료하지 않으면, 스크린이 사라질 수 있어요 (디스플레이 옵션 목록이 null이 되기 때문).
+
+이것은 수정 대기 중인 버그로, 현재는 Warudo를 종료하고 다시 열어야만 해결할 수 있어요. (변경 사항은 저장할 수 있어요)
+
+
+![](/doc-img/pen-display-hand-sync-8.png)
+
+<AuthorBar authors={{
+  creators: [
+    {name: 'Hane', github: 'hanekit'},
+  ],
+  translators: [
+    {name: 'Puri', github: 'Puri12'},
+  ],
+}} />

--- a/i18n/ko/docusaurus-plugin-content-docs/current/mocap/vicon.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/mocap/vicon.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 512
+version: 2025-11-04
+---
+
+# Vicon Shogun
+
+:::info
+이 기능은 [Warudo Pro](../pro)에서만 사용할 수 있어요.
+:::
+
+[Vicon Shogun](https://www.vicon.com/software/shogun/)을 통한 바디 트래킹. [Vicon](https://www.vicon.com) 광학 트래킹 시스템에 대한 접근이 필요해요.
+
+캐릭터 추적 외에도 소품 추적도 지원돼요. 예를 들어, Shogun에서 추적된 카메라, 핸드헬드 소품, 또는 스테이지 마커를 스트리밍하여 해당하는 Warudo 소품이나 카메라를 실시간으로 애니메이션할 수 있어요.
+
+## 설정
+
+Warudo에서 **Menu → Settings → Vicon**으로 이동하세요. **Server Address**가 Shogun이 실행 중인 PC를 가리키고 있는지 확인하세요 (예: `192.168.1.50:801`). Warudo와 Shogun이 같은 머신에서 실행 중이라면, 기본값인 `localhost:801`을 유지하면 돼요.
+
+**Enabled**를 Yes로 설정하세요. Warudo가 연결을 설정하면 "Connected to Vicon Shogun"이라는 상태 메시지가 표시될 거예요.
+
+![](/doc-img/en-vicon-1.jpg)
+
+### 캐릭터 추적
+
+Vicon Shogun을 Warudo에 연결하려면, [Onboarding Assistant](../tutorials/readme-1) (또는 **Character → Setup Motion Capture** 실행)를 사용하고 포즈 추적으로 **Vicon Shogun**을 선택하세요. 설정이 완료되면 씬에 **Vicon Subject Receiver** 에셋이 표시될 거예요. **Vicon Subject Name** 필드가 Shogun의 이름과 일치하는지 확인하세요.
+
+:::tip
+Warudo 캐릭터의 본 이름이 Shogun 스켈레톤에서 사용하는 이름과 다른 경우, **Vicon Receiver** 에셋의 **Override Bone Names**를 사용하여 특정 휴머노이드 본을 Shogun에서 제공하는 이름에 매핑할 수 있어요.
+:::
+
+![](/doc-img/en-vicon-2.jpg)
+
+### 소품 추적
+
+Warudo에서 **Vicon Prop Receiver** 에셋을 생성하세요. **Vicon Prop Name**을 Shogun Live의 리지드 바디 라벨로 설정하고, **Target Asset**에서 Warudo 소품 또는 카메라를 선택하세요.
+
+:::info
+Warudo 소품 파일의 계층 구조는 Shogun의 것과 일치해야 하며, 루트 트랜스폼의 이름은 `root`여야 해요. 그렇지 않으면 Warudo가 루트 트랜스폼을 생성하지만, 하위 트랜스폼이 완전히 미러링되지 않을 수 있어요.
+:::
+
+:::tip
+blueprint에서 추적 데이터에 접근하려면, **Get Vicon Subject Receiver Data** 또는 **Get Vicon Prop Receiver Data** 노드를 사용할 수 있어요.
+:::
+
+## 고급 옵션
+
+* **Root Rotation Offset**: 캐릭터나 소품이 Vicon 좌표 프레임과 다른 전방 방향을 향하고 있는 경우 정적 오프셋을 적용해요. 일반적으로 이 설정을 변경할 필요는 없어요.
+* **Use Pre Fetch**: 지연 시간에 민감한 설정을 위해 Vicon Shogun에서 버퍼링된 프레임을 요청해요.
+
+## 자주 묻는 질문
+
+일반적인 질문은 [개요](overview#FAQ)와 [포즈 추적 커스터마이징](body-tracking#FAQ)을 참조해 주세요.
+
+### "Failed to connect to Vicon system"이라는 상태가 표시돼요.
+
+Shogun PC와 Warudo PC가 같은 서브넷에 있는지 확인하세요. **Server Address**를 다시 확인하고, 방화벽에서 `801` 포트가 열려 있는지 확인하세요.
+
+### 캐릭터가 잘못된 포즈로 튀어요.
+
+Shogun의 서브젝트가 Warudo 캐릭터와 호환되는 스켈레톤을 사용하고 있는지 확인하세요 (일치하는 본 계층 구조와 제로화된 T-포즈 회전). 필요한 경우, **Override Bone Names**를 사용하여 관절 이름을 맞추고, **Root Rotation Offset**을 사용하여 좌표 프레임을 일치시키세요.
+
+<AuthorBar authors={{
+  creators: [
+    {name: 'HakuyaTira', github: 'TigerHix'},
+  ],
+  translators: [
+    {name: 'Puri', github: 'Puri12'},
+  ],
+}} />

--- a/i18n/ko/docusaurus-plugin-content-docs/current/scripting/mod-interoperability.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/scripting/mod-interoperability.md
@@ -1,0 +1,201 @@
+---
+sidebar_position: 11
+version: 2025-12-11
+---
+
+# 모드 상호운용성
+
+Warudo 0.14.3부터 모드 간에 서로 호출할 수 있게 되었어요. 모드는 uMod의 참조 의존성 시스템을 사용할 필요 없이, 새로운 `PluginRouter` 메커니즘을 사용하여 상호운용할 수 있어요.
+
+## 시그널과 슬롯
+모드는 시그널을 통해 다른 모드에 단방향, 비방향성 메시지를 보낼 수 있어요. 이는 일반적으로 내부 모드 이벤트를 브로드캐스트하는 데 사용돼요 — 예를 들어, 환경이 내부 애니메이션의 시작과 끝을 브로드캐스트하거나, 충돌 상태, 미리 정의된 환경 이벤트의 트리거 여부, 또는 다른 모드가 자동으로 동기화할 수 있는 기타 모드 내부 상태 등이에요.
+
+### 시그널 발신
+시그널을 발신하려면 유효한 `Plugin`/`Asset`/`Node` 인스턴스가 필요하고, `Warudo.Core.Events.Event`를 상속하는 클래스와 함께 `EmitSignal` 인스턴스 메서드를 호출하면 돼요:
+
+```csharp
+[AssetType(Id="AMod.Asset")]
+public class AModAsset: Asset {
+    public class MyEventOnA : Warudo.Core.Events.Event
+    {
+        public string message;
+    }
+
+    [Trigger]
+    public void OnSomeEvent()
+    {
+        this.EmitSignal(new MyEventOnA {
+            message = "Hello from MyMod!"
+        });
+    }
+}
+```
+
+:::tips
+이것은 다음과 동일해요:
+```csharp
+Context.PluginRouter.EmitSignal(this, new MyEventOnA {
+    message = "Hello from MyMod!"
+});
+```
+
+:::
+
+### 슬롯 연결
+시그널을 수신하려면, `Plugin`/`Asset`/`Node` 인스턴스에서 `ConnectSlot`을 호출하고, 발신자 타입 ID와 콜백을 전달하면 돼요:
+
+```csharp
+[AssetType(Id="BMod.Asset")]
+public class BModAsset: Asset {
+    public class MyEventOnB : Warudo.Core.Events.Event
+        {
+            public string message;
+        }
+        public override void OnCreate()
+        {
+            base.OnCreate();
+            var link = ConnectSlot<MyEventOnB>("AMod.Asset", (evt, entity) => {
+                // evt는 Signal 인스턴스, 이 경우 MyEventOnB
+                // entity는 시그널을 보낸 엔티티, 이 경우 AModAsset의 인스턴스
+            });
+            // 슬롯 연결 해제. 인스턴스가 파괴될 때 자동으로 연결 해제돼요
+            DisconnectSlot(link); 
+        }
+}
+```
+
+위 예시에서 `ConnectSlot`의 첫 번째 인자 (`"AMod.Asset"`)는 시그널 발신자의 타입 ID로, 어떤 `Plugin`/`Asset`/`Node` 타입 ID든 될 수 있어요. `MyEventOnA`와 `MyEventOnB`는 내부 구조가 동일하기만 하면 상호운용이 가능해요.
+
+:::tips
+이것은 다음과 동일해요:
+```csharp
+var link = Context.PluginRouter.ConnectSlot<MyEventOnB>(this, "AMod.Asset", (e, s) => {
+    if (CanReceiveEvents) {
+        handler(e, s);
+    }
+});
+```
+
+:::
+
+## 커맨드
+모드는 커맨드를 사용하여 양방향으로 통신할 수도 있어요. 시그널과 달리, 커맨드는 방향이 있는 요청-응답 상호작용이에요: 발신자가 수신자의 응답을 기다려요.
+
+### 커맨드 등록
+커맨드를 등록하려면, `Plugin`/`Asset`/`Node` 인스턴스에서 `RegisterCommand`를 호출하고 커맨드 이름과 콜백을 제공하면 돼요:
+
+```csharp
+[AssetType(Id="AMod.Asset")]
+public class AModAsset: Asset {
+    public class MyCommandRequestOnA
+    {
+        public string message;
+    }
+    public class MyCommandResponseOnA
+    {
+        public int time;
+        public string message;
+    }
+
+    [Trigger]
+    public void OnSomeEvent()
+    {
+        var commandId = this.RegisterCommand<MyCommandRequestOnA, MyCommandResponseOnA>("MyCommand", (req) => {
+                    // req는 커맨드 요청 파라미터
+                    Debug.Log($"AMod received command: {req.message}");
+                    // 반환 값
+                    return new MyCommandResponseOnA {
+                        time = DateTime.Now.Millisecond,
+                        message = "Response from AMod"
+                    };
+                });
+    }
+}
+```
+
+등록을 해제하려면 `UnregisterCommand`를 호출하세요. 인스턴스가 파괴될 때 등록은 자동으로 제거돼요:
+```csharp
+this.UnregisterCommand(commandId);
+```
+
+### 커맨드 실행
+커맨드를 보내려면 유효한 **대상** `Plugin`/`Asset`/`Node` 인스턴스가 필요해요. `PluginRouter`의 `ExecuteCommand` 메서드를 사용하여 커맨드를 보내세요:
+
+```csharp
+public class MyCommandRequestOnB
+{
+    public string message;
+}
+public class MyCommandResponseOnB
+{
+    public int time;
+    public string message;
+}
+
+[DataInput]
+[TypeIdFilter("AMod.Asset")]
+Asset targetEntity;
+
+// 커맨드 실행
+CommandResult<MyCommandResponseOnB> commandResult = Context.PluginRouter.ExecuteCommand<MyCommandRequestOnB, MyCommandResponseOnB>(
+    targetEntity, // 대상 엔티티, Plugin/Asset/Node 인스턴스가 될 수 있어요
+    "MyCommand",  // 커맨드 이름
+    new MyCommandRequestOnB { // 커맨드 요청 파라미터
+        message = "Hello from BMod!"
+    }
+);
+```
+
+이 메서드는 커맨드의 결과를 담고 있는 `CommandResult<TResponse>` 인스턴스를 반환해요:
+
+```csharp
+public class CommandResult<T>
+{
+    public CommandResultStatus Status;
+    public T Data;
+}
+```
+
+`CommandResultStatus`는 커맨드의 실행 상태를 나타내는 열거형이에요:
+
+```csharp
+public enum CommandResultStatus
+{
+    SUCCESS, // 성공적으로 실행됨
+    ENTITY_NOT_FOUND, // 대상 엔티티를 찾을 수 없음
+    COMMAND_NOT_FOUND, // 대상 엔티티가 이 커맨드를 등록하지 않음
+    EXECUTION_ERROR // 커맨드 실행 중 오류 발생
+}
+```
+
+`Status` 필드를 확인하여 커맨드가 성공했는지 판단하고, `Data` 필드를 통해 응답에 접근할 수 있어요:
+```csharp
+if (commandResult.Status == CommandResultStatus.SUCCESS)
+{
+    Debug.Log($"BMod received response: {commandResult.Data.message} at {commandResult.Data.time}");
+}
+else
+{
+    Debug.LogError($"Command execution failed with status: {commandResult.Status}");
+}
+```
+
+:::tips
+
+시그널과 마찬가지로, 커맨드의 요청 및 응답 타입도 내부 구조가 일치하기만 하면 상호운용이 가능해요.
+
+:::
+
+### 커맨드 존재 여부 쿼리
+```csharp
+Context.PluginRouter.HasCommand<TArgs>(targetEntity, "CommandName"); // bool을 반환
+```
+
+<AuthorBar authors={{
+  creators: [
+    {name: 'LiYin', github: 'cubesky'}
+  ],
+  translators: [
+    {name: 'Puri', github: 'Puri12'},
+  ],
+}} />

--- a/i18n/ko/docusaurus-plugin-content-docs/current/tutorials/data-folder.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/tutorials/data-folder.md
@@ -1,0 +1,290 @@
+---
+sidebar_position: 40
+version: 2026-01-19
+---
+
+# 데이터 폴더
+
+Warudo의 데이터 폴더는 `StreamingAssets`라는 이름의 폴더로, Warudo가 사용할 수 있는 다양한 데이터 파일을 저장하는 데 사용돼요.
+
+---
+
+## 찾는 방법
+
+**Menu** ➜ **Open data folder**를 클릭하면 열 수 있어요.
+
+![](/doc-img/data-folder-1.png)
+
+일반적으로 다음 경로에 위치해요:
+
+```
+<STEAM_ROOT_DIR>\steamapps\common\Warudo\Warudo_Data\StreamingAssets
+```
+
+## 하위 폴더
+
+데이터 폴더에는 여러 하위 폴더가 있으며, 서로 다른 유형의 파일을 분류하는 데 사용돼요.
+
+자세한 내용은 다음과 같아요 (알파벳 순서):
+
+### Binaries
+
+이 폴더에는 프로그램과 관련된 일부 바이너리 파일이 포함되어 있어요.
+삭제하거나 수정하지 마세요.
+
+### CharacterAnimationProfiles
+
+이 폴더는 **캐릭터의 애니메이션 프로필** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:** JSON (`*.json`)
+
+"[**Character**](/docs/assets/character)" 에셋의 "**Animation**" 섹션에서 "**Save Animation Profile**" 버튼을 사용하면, 캐릭터의 현재 애니메이션 설정이 이 폴더에 저장돼요.
+
+프로필 파일은 다음 시나리오에서 사용할 수 있어요:
+- "[**Character**](/docs/assets/character)" 에셋 – "**Animation**" 섹션 – "**Load Animation Profile**" 버튼
+- "**Load Character Animation Profile**" 노드 – "**Animation Profile**" 포트
+
+"[**Character**](/docs/assets/character)" 에셋의 "**Animation**" 섹션에서 "**Open Animation Profiles Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### CharacterAnimations
+
+이 폴더는 캐릭터가 재생할 수 있는 **캐릭터 애니메이션** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:**
+- Unity Animation Clip (`*.anim`)
+- [Warudo Character Animation Mod](/docs/modding/character-animation-mod) (`*.warudo`)
+
+애니메이션 파일은 다음 시나리오에서 사용할 수 있어요:
+
+- "[**Character**](/docs/assets/character)" 에셋 – "**Animation**" 섹션 – "**Idle Animation**" 옵션
+- "[**Character**](/docs/assets/character)" 에셋 – "**Animation**" 섹션 – "**Overlaying Animations**" – "**Animation**" 옵션
+- "**Character Animation Source**" 노드 – "**Value**" 포트
+- "**Get Random Character Animation**" 노드 – "**Character Animations**" 포트
+- "**Play Character One Shot Overlay Animation**" 노드 – "**Animation**" 포트
+- "**Play Character Idle Animation**" 노드 – "**Animation**" 포트
+
+"[**Character**](/docs/assets/character)" 에셋의 "**Animation**" 섹션에서 "**Open Character Animations Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### CharacterExpressionProfiles
+
+이 폴더는 **캐릭터의 표정 프로필** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:** JSON (`*.json`)
+
+"[**Character**](/docs/assets/character)" 에셋의 "**Expressions**" 섹션에서 "**Save Expression Profile**" 버튼을 사용하면, 캐릭터의 현재 표정 설정이 이 폴더에 저장돼요.
+
+프로필 파일은 다음 시나리오에서 사용할 수 있어요:
+- "[**Character**](/docs/assets/character)" 에셋 – "**Expressions**" 섹션 – "**Load Expression Profile**" 버튼
+
+"[**Character**](/docs/assets/character)" 에셋의 "**Expressions**" 섹션에서 "**Open Expression Profiles Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### Characters
+
+이 폴더는 **캐릭터 모델** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:**
+- VRM 0.x Model (`*.vrm`)
+- VRM 1.0 Model (`*.vrm`)
+- [Warudo Character Mod](/docs/modding/character-mod) (`*.warudo`)
+
+이 파일들은 "[**Character**](/docs/assets/character)" 에셋의 "**Source**" 옵션에서 사용할 수 있어요.
+
+"[**Character**](/docs/assets/character)" 에셋에서 "**Open Characters Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### Clients
+
+이 폴더에는 프로그램과 관련된 일부 파일이 포함되어 있어요.
+삭제하거나 수정하지 마세요.
+
+### Environments
+
+이 폴더는 **환경** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:** [Warudo Environment Mod](/docs/modding/environment-mod) (`*.warudo`)
+
+이 파일들은 "[**Environment**](/docs/assets/environment)" 에셋의 "**Source**" 옵션에서 사용할 수 있어요.
+
+"[**Environment**](/docs/assets/environment)" 에셋에서 "**Open Environments Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### HandGestureProfiles
+
+이 폴더는 **캐릭터의 손 제스처** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:** JSON (`*.json`)
+
+"**Detect Character Hand Gesture**" 노드에서 "**Record New Hand Gesture**" 버튼을 사용하면, 캐릭터의 손 제스처가 이 폴더에 저장돼요.
+
+프로필 파일은 다음 시나리오에서 사용할 수 있어요:
+- "**Detect Character Hand Gesture**" 노드 – "**Gesture**" 포트
+
+### HandPoses
+
+이 폴더는 **캐릭터의 손 포즈** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:** **(개발 중 ...)**
+
+손 포즈 파일은 다음 시나리오에서 사용할 수 있어요:
+
+- "[**Character**](/docs/assets/character)" 에셋 – "**Animation**" 섹션 – "**Override Hand Poses**" 옵션 – "**Pose**" 옵션
+- "**Enable Character Override Hand Pose**" 노드 – "**Pose**" 포트
+
+### Images
+
+이 폴더는 **이미지** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:** 이미지 형식
+
+이미지 파일은 다음 시나리오에서 사용할 수 있어요:
+- "**Spawn Sticker From Local Image**" 노드 – "**Image Source**" 포트 – "**Get Random Local Image**" 노드 – "**Images**" 포트
+- "[**Screen**](/docs/assets/screen)" 에셋 – "**Image Source**" 옵션 ("**Content Type**"이 "**Image**"여야 해요)
+- "**Discover**" 패널 – "**Published Items**" 탭 – "**Create Item**" – "**Preview Image**" 옵션
+
+### LipSyncProfiles
+
+이 폴더에는 프로그램과 관련된 일부 파일이 포함되어 있어요.
+삭제하거나 수정하지 마세요.
+
+### Localizations
+
+이 폴더에는 프로그램과 관련된 일부 파일이 포함되어 있어요.
+삭제하거나 수정하지 마세요.
+
+### MMD
+
+**지원 형식:** [Vocaloid Motion Data (MikuMikuDance)](https://mikumikudance.fandom.com/wiki/VMD_file_format) (`*.vmd`)
+
+파일은 다음 시나리오에서 사용할 수 있어요:
+- "**MMD Player**" 에셋 – "**Character Motion**" 옵션
+
+### Motions
+
+**지원 형식:** Warudo Animation Data (`*.wanim`)
+
+Warudo Animation Data 파일은 "**Motion Recorder**" 에셋으로 생성할 수 있어요.
+
+파일은 다음 시나리오에서 사용할 수 있어요:
+- "**Motion Player**" 에셋 – "**Motion Sources**" 옵션
+
+"**Motion Recorder**" 에셋에서 "**Open Motions Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### Music
+
+**지원 형식:** 오디오 형식
+
+파일은 다음 시나리오에서 사용할 수 있어요:
+- "**Music Player**" 에셋 – "**Source**" 옵션
+- "**Play Music**" 노드 – "**Source**" 포트
+- "**Music Source**" 노드 – "**Value**" 포트
+
+"**Music Player**" 에셋에서 "**Open Music Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### Particles
+
+**지원 형식:** [Warudo Particle Mod](/docs/modding/particle-mod) (`*.warudo`)
+
+파일은 다음 시나리오에서 사용할 수 있어요:
+- "[**Prop**](/docs/assets/prop)" 에셋 – "**Source**" 옵션
+- "**Particle Source**" 노드 – "**Value**" 포트
+- "**Get Random Particle**" 노드 – "**Particles**" 포트
+- "**Spawn Particle**" 노드 – "**Source**" 포트
+- "**Throw Prop**" 노드 – "**Impact Particle Source**" 포트
+
+### PendulumPhysicsProfiles
+
+이 폴더는 **진자 물리 프로필** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:** JSON (`*.json`)
+
+파일은 다음 시나리오에서 사용할 수 있어요:
+- **Motion Capture** 에셋 – "**Pendulum Physics**" 섹션 – "**Load Pendulum Physics Profile**" 버튼
+- "**Load Pendulum Physics Profile**" 노드 – "**Pendulum Physics Profile**" 포트
+
+**Motion Capture** 에셋의 "**Pendulum Physics**" 섹션에서 "**Open Pendulum Physics Profiles Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### Playground
+
+**지원 형식:** C# Source Code File (`*.cs`)
+
+다음을 참고해 주세요: [Playground](/docs/scripting/playground)
+
+### Plugins
+
+**지원 형식:** [Warudo Plugin Mod](/docs/scripting/creating-your-first-plugin-mod) (`*.warudo`)
+
+### Props
+
+**지원 형식:** [Warudo Prop Mod](/docs/modding/prop-mod) (`*.warudo`)
+
+파일은 다음 시나리오에서 사용할 수 있어요:
+- "[**Prop**](/docs/assets/prop)" 에셋 – "**Source**" 옵션
+- "**Prop Source**" 노드 – "**Value**" 포트
+- "**Get Random Prop**" 노드 – "**Props**" 포트
+- "**Throw Prop**" 노드 – "**Prop Source**" 포트
+
+"[**Prop**](/docs/assets/prop)" 에셋에서 "**Open Props Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### Scenes
+
+이 폴더는 **Warudo 씬** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:** JSON (`*.json`)
+
+씬 파일은 다음 시나리오에서 사용할 수 있어요:
+- **Menu** – **Open scene**
+
+### Screenshots
+
+"[**Camera**](/docs/assets/camera)" 에셋의 "**Output**" 섹션에서 "**Take Screenshot**" 버튼을 사용하면, 카메라의 현재 출력이 PNG 형식으로 이 폴더에 저장돼요.
+
+마찬가지로, "**Take Screenshot**" 노드를 실행하면 선택된 카메라의 현재 출력이 PNG 형식으로 이 폴더에 저장돼요.
+
+### Sounds
+
+**지원 형식:** 오디오 형식
+
+파일은 다음 시나리오에서 사용할 수 있어요:
+- "**Play Sound**" 노드 – "**Source**" 포트
+- "**Sound Source**" 노드 – "**Value**" 포트
+- "**Get Random Sounds**" 노드 – "**Sounds**" 포트
+- "**Throw Prop**" 노드 – "**Launch/Impact Sound Source**" 포트
+
+"**Play Sound**" 노드에서 "**Open Sounds Folder**" 버튼을 사용하면 이 폴더를 직접 열 수도 있어요.
+
+### SteamVR
+
+이 폴더에는 프로그램과 관련된 일부 파일이 포함되어 있어요.
+삭제하거나 수정하지 마세요.
+
+### Videos
+
+이 폴더는 **비디오** 파일을 저장하는 데 사용돼요.
+
+**지원 형식:** 비디오 형식
+
+비디오 파일은 다음 시나리오에서 사용할 수 있어요:
+- "[**Screen**](/docs/assets/screen)" 에셋 – "**Video Source**" 옵션 ("**Content Type**"이 "**Video**"여야 해요)
+
+## 추가 하위 폴더
+
+:::tip
+Steam 워크샵의 일부 플러그인은 `StreamingAssets` 아래에 추가 하위 폴더를 생성할 수도 있어요.
+:::
+
+Warudo와 관련된 파일을 더 잘 관리하기 위해 다음 하위 폴더를 만드는 것도 권장해요:
+
+### AssetProfiles
+
+이 폴더는 "**Export asset to file**" 버튼으로 생성한 **에셋 프로필** 파일을 저장하는 데 사용할 수 있어요.
+
+### Blueprints
+
+이 폴더는 "**Export blueprint to file**" 버튼으로 생성한 **blueprint** 파일을 저장하는 데 사용할 수 있어요.
+
+<AuthorBar authors={{
+  creators: [
+    {name: 'Hane', github: 'hanekit'},
+  ],
+  translators: [
+    {name: 'Puri', github: 'Puri12'},
+  ],
+}} />


### PR DESCRIPTION
## Summary

Add Korean translations for all remaining untranslated documentation pages.

## Translated Pages

| Page | Description |
|------|-------------|
| `blueprints/miscellaneous/transition-easing` | Transition easing reference |
| `blueprints/miscellaneous/streamdeck-integration` | Stream Deck integration guide |
| `blueprints/templates/pen-display-hand-sync` | Pen display hand sync tutorial |
| `mocap/vicon` | Vicon Shogun motion capture setup |
| `scripting/mod-interoperability` | Mod interoperability API (signals, slots, commands) |
| `tutorials/data-folder` | Data folder structure reference |

## Notes

- Translation style follows the existing Korean translations (casual polite tone using 해요체)
- Technical terms and UI element names are kept in English, consistent with other ko pages
- Image paths use absolute `/doc-img/` format, consistent with existing ko translations
- `AuthorBar` translator field populated for all pages