### PR TITLE
Fix broken links and content errors in the English documentation

### DIFF
--- a/docs/assets/character.md
+++ b/docs/assets/character.md
@@ -118,7 +118,7 @@ In addition to body animations, you can also set up **Breathing Animation** and 
 Finally, you can use **Additional Bone Offsets** to make small adjustments to the character's posture; for example, if you want to make the character's head tilt a few degrees to one side.
 
 :::info
-By default, the priority of the idle animation, overlay animations, override hand poses, and [body IK](./#body-ik) are all **lower** than motion capture.
+By default, the priority of the idle animation, overlay animations, override hand poses, and [body IK](#body-ik) are all **lower** than motion capture.
 
 For example, even if you have set an override hand pose for your right hand, if your right hand is being tracked, say by MediaPipe, the model follows your right hand's pose instead of the override hand pose. To make the override hand pose take priority over motion capture, you can enable **High Priority** in the hand pose settings.
 :::

--- a/docs/blueprints/templates/pen-display-hand-sync.md
+++ b/docs/blueprints/templates/pen-display-hand-sync.md
@@ -117,7 +117,7 @@ You can use the **Onboarding Assistant** to configure your own character, enviro
 
 You can also customize the positions of the character and screen.
 
-For different characters, you may need to adjust the values of **`Trnasform` - `Position`** in **`Anchor - Right Hand IK`** to make the character hold the pen better.
+For different characters, you may need to adjust the values of **`Transform` - `Position`** in **`Anchor - Right Hand IK`** to make the character hold the pen better.
 
 :::warning
 

--- a/docs/blueprints/tutorials/balloon.md
+++ b/docs/blueprints/tutorials/balloon.md
@@ -54,11 +54,11 @@ This node takes a Vector3 (i.e., three decimal numbers X, Y, and Z) and a float 
 
 For now, let's set the **Vector3** option to (2, 2, 2) and connect the nodes together like above, and see what happens when we puff our cheeks.
 
-Huh, nothing is happening...? That is because the Get Character Bone Scale node is never triggered! For now, let's just manually trigger it. Puff your cheeks again, but this time also click on **Get Character Bone Scale → Enter**. You should see your character's head grow bigger!
+Huh, nothing is happening...? That is because the Set Character Bone Scale node is never triggered! For now, let's just manually trigger it. Puff your cheeks again, but this time also click on **Set Character Bone Scale → Enter**. You should see your character's head grow bigger!
 
 ![](/doc-img/en-blueprint-balloon-5.png)
 
-But here's a problem: if you stop puffing your cheeks and click on **Get Character Bone Scale → Enter** again, your character's head will become like this:
+But here's a problem: if you stop puffing your cheeks and click on **Set Character Bone Scale → Enter** again, your character's head will become like this:
 
 ![](/doc-img/en-blueprint-balloon-6.png)
 
@@ -82,14 +82,14 @@ To see why this works, let's run through the calculations again. When we puff ou
 
 ## On Update {#on-update}
 
-I hope you hated manually triggering the Get Character Bone Scale node as much as I did. Indeed, we can't be clicking in our blueprint every time we want to inflate our character's head. Only if there is a way to automatically trigger the node... Wait, there is?
+I hope you hated manually triggering the Set Character Bone Scale node as much as I did. Indeed, we can't be clicking in our blueprint every time we want to inflate our character's head. Only if there is a way to automatically trigger the node... Wait, there is?
 
 ![](/doc-img/en-blueprint-balloon-9.png)
 
 The **On Update** node is an event node that is triggered every frame when Warudo is running. For instance, if Warudo runs at 60 FPS, then the On Update node will be triggered 60 times per second. This node saved us from clicking 60 times per second, whew.
 
 :::tip
-Remember you can add nodes after the Get Character Bone Scale node to trigger more effects using your cheeks! Try to add a **Set Character BlendShape** node to activate a blendshape on your character when you puff your cheeks. Hint: Set Character BlendShape → Target Value is a decimal number between 0 and 1, so you can connect Get Character BlendShape → Value directly to it.
+Remember you can add nodes after the Set Character Bone Scale node to trigger more effects using your cheeks! Try to add a **Set Character BlendShape** node to activate a blendshape on your character when you puff your cheeks. Hint: Set Character BlendShape → Target Value is a decimal number between 0 and 1, so you can connect Get Character BlendShape → Value directly to it.
 :::
 
 ## Resetting Bone Scale {#resetting-bone-scale}

--- a/docs/blueprints/tutorials/dance.md
+++ b/docs/blueprints/tutorials/dance.md
@@ -15,7 +15,7 @@ Looking for a fun way to thank your viewers for their support? In this tutorial,
 Before we get started, you need to use the onboarding assistant to connect Warudo to your Twitch, YouTube or Bilibili account. If you haven't done so, please refer to the [Getting Started](../../tutorials/getting-started.md#interaction-setup) tutorial. We will assume you stream on Twitch in this tutorial, but the steps are similar for other platforms.
 
 :::tip
-You can also use third-party integration such as [Streamer.bot](Streamer.bot) that can send a WebSocket message to Warudo when you receive a donation or other stream events. In that case, you don't need to use the onboarding assistant.
+You can also use third-party integration such as [Streamer.bot](https://streamer.bot/) that can send a WebSocket message to Warudo when you receive a donation or other stream events. In that case, you don't need to use the onboarding assistant.
 :::
 
 Let's start with a minimal example: when I receive a Twitch redeem, I want my character to dance. We need only two nodes:

--- a/docs/mocap/chingmu.md
+++ b/docs/mocap/chingmu.md
@@ -47,7 +47,7 @@ Please refer to [Overview](overview#FAQ) and [Customizing Pose Tracking](body-tr
 
 First, make sure you have loaded the same model in Warudo and Chingmu Avatar.
 
-We also require the models to have normalized bones,  i.e., all bones on the model should have zero rotation (0, 0, 0) when the model is in T-pose. Please refer to [this page](../misc/normalizing-model-bones) for more details.
+We also require the models to have normalized bones,  i.e., all bones on the model should have zero rotation (0, 0, 0) when the model is in T-pose. Please refer to [this page](../modding/character-mod#normalize-bones) for more details.
 
 ### My character is not moving.
 

--- a/docs/mocap/motionbuilder.md
+++ b/docs/mocap/motionbuilder.md
@@ -61,7 +61,7 @@ Please refer to [Overview](overview#FAQ) and [Customizing Pose Tracking](body-tr
 
 First, make sure you have loaded the same model in Warudo and Autodesk MotionBuilder.
 
-We also require the models to have normalized bones,  i.e., all bones on the model should have zero rotation (0, 0, 0) when the model is in T-pose. Please refer to [this page](../misc/normalizing-model-bones) for more details.
+We also require the models to have normalized bones,  i.e., all bones on the model should have zero rotation (0, 0, 0) when the model is in T-pose. Please refer to [this page](../modding/character-mod#normalize-bones) for more details.
 
 ### I have confirmed Autodesk MotionBuilder is streaming data to another PC running Warudo, but Warudo has not received any data.
 

--- a/docs/mocap/optitrack.md
+++ b/docs/mocap/optitrack.md
@@ -25,7 +25,7 @@ To connect OptiTrack Motive to Warudo, please enable **Streaming** in OptiTrack 
 
 ![](/doc-img/en-optitrack-2.png)
 
-Then, use the [Onboarding Assistant](../tutorials/readme-1) (or run **Character → Setup Motion Capture**) and select **OptiTrack Motive** for pose tracking. After the setup is complete, you should be able to see an **OptiTrack Skeleton Receiver** asset in your scene. Make sure the **OptiTrack Skeleton Name** field matches the one in OptiTrack Motive:
+Then, use the [Onboarding Assistant](../tutorials/getting-started) (or run **Character → Setup Motion Capture**) and select **OptiTrack Motive** for pose tracking. After the setup is complete, you should be able to see an **OptiTrack Skeleton Receiver** asset in your scene. Make sure the **OptiTrack Skeleton Name** field matches the one in OptiTrack Motive:
 
 ![](/doc-img/en-optitrack-3.png)
 

--- a/docs/mocap/vicon.md
+++ b/docs/mocap/vicon.md
@@ -23,7 +23,7 @@ Set **Enabled** to Yes. You should see a status message that says "Connected to 
 
 ### Character Tracking
 
-To connect Vicon Shogun to Warudo, use the [Onboarding Assistant](../tutorials/readme-1) (or run **Character → Setup Motion Capture**) and select **Vicon Shogun** for pose tracking. After the setup is complete, you should be able to see a **Vicon Subject Receiver** asset in your scene. Make sure the **Vicon Subject Name** field matches the one in Shogun.
+To connect Vicon Shogun to Warudo, use the [Onboarding Assistant](../tutorials/getting-started) (or run **Character → Setup Motion Capture**) and select **Vicon Shogun** for pose tracking. After the setup is complete, you should be able to see a **Vicon Subject Receiver** asset in your scene. Make sure the **Vicon Subject Name** field matches the one in Shogun.
 
 :::tip
 If your Warudo character has different bone names than the ones used in the Shogun skeleton, use **Override Bone Names** on the **Vicon Receiver** asset to map specific humanoid bones to the names exposed by Shogun.

--- a/docs/mocap/vmc.md
+++ b/docs/mocap/vmc.md
@@ -45,7 +45,7 @@ Please refer to [Overview](overview#FAQ) and [Customizing Pose Tracking](body-tr
 
 First, make sure you have loaded the same model in Warudo and the external application.
 
-We also require the models to have normalized bones,  i.e., all bones on the model should have zero rotation (0, 0, 0) when the model is in T-pose. If your model is in [VRM format](https://vrm.dev/), then in most cases there should be no issue. However, in very rare cases, the modeler may not have checked the Enforce T-Pose option when exporting, and it can be fixed by re-exporting with this option checked. Please refer to [this page](../misc/normalizing-model-bones) for more details.
+We also require the models to have normalized bones,  i.e., all bones on the model should have zero rotation (0, 0, 0) when the model is in T-pose. If your model is in [VRM format](https://vrm.dev/), then in most cases there should be no issue. However, in very rare cases, the modeler may not have checked the Enforce T-Pose option when exporting, and it can be fixed by re-exporting with this option checked. Please refer to [this page](../modding/character-mod#normalize-bones) for more details.
 
 <AuthorBar authors={{
   creators: [

--- a/docs/scripting/api/io.md
+++ b/docs/scripting/api/io.md
@@ -7,7 +7,7 @@ version: 2024-06-16
 
 ## Using Data Inputs
 
-[Data inputs](ports-and-triggers#data-inputs) in entities are automatically serialized. That means if you need to store any data in your custom asset or node, the best way is to simply define a data input:
+[Data inputs](ports-and-triggers#data-input-ports) in entities are automatically serialized. That means if you need to store any data in your custom asset or node, the best way is to simply define a data input:
 
 ```csharp
 [DataInput]

--- a/docs/scripting/api/ports-and-triggers.md
+++ b/docs/scripting/api/ports-and-triggers.md
@@ -284,7 +284,7 @@ BroadcastDataInput(nameof(MyNumber));
 
 However, in this case, the second method is **strongly recommended** due to two reasons:
 
-1. It ensures [watchers](operations#watchers) of this data input are notified of the change.
+1. It ensures [watchers](watchers) of this data input are notified of the change.
 2. By setting the `broadcast` parameter to `true`, the change is sent to the editor. Otherwise, you need to use `BroadcastDataInput(string key)` to manually send the change to the editor.
 
 You should use the first method only if:

--- a/docs/scripting/mod-interoperability.md
+++ b/docs/scripting/mod-interoperability.md
@@ -31,7 +31,7 @@ public class AModAsset: Asset {
 }
 ```
 
-:::tips
+:::tip
 This is equivalent to calling
 ```csharp
 Context.PluginRouter.EmitSignal(this, new MyEventOnA {
@@ -66,7 +66,7 @@ public class BModAsset: Asset {
 
 In the example above, the first argument to `ConnectSlot` (`"AMod.Asset"`) is the type ID of the signal sender — it can be any `Plugin`/`Asset`/`Node` type ID. `MyEventOnA` and `MyEventOnB` are interoperable as long as their internal structure is the same.
 
-:::tips
+:::tip
 This is equivalent to calling
 ```csharp
 var link = Context.PluginRouter.ConnectSlot<MyEventOnB>(this, "AMod.Asset", (e, s) => {
@@ -180,7 +180,7 @@ else
 }
 ```
 
-:::tips
+:::tip
 
 Like signals, command request and response types are interoperable as long as their internal structure matches.
 

--- a/docs/tutorials/data-folder.md
+++ b/docs/tutorials/data-folder.md
@@ -135,7 +135,8 @@ This folder is used to store the **image** files.
 **Supported Format:** Image formats
 
 You can use the image files in the following scenarios:
-- “**Spawn Sticker From Local Image**” Node – “**Image Source**” Port – “**Get Random Local Image**” Node – “**Images**” Port
+- “**Spawn Sticker From Local Image**” Node – “**Image Source**” Port
+- “**Get Random Local Image**” Node – “**Images**” Port
 - “[**Screen**](/docs/assets/screen)” Asset – “**Image Source**” Option (“**Content Type**” should be “**Image**”)
 - “**Discover**” Panel – “**Published Items**” Tab – “**Create Item**” – “**Preview Image**” Option
 
@@ -221,7 +222,7 @@ You can use the files in the following scenarios:
 - “**Get Random Prop**” Node – “**Props**” Port
 - “**Throw Prop**” Node – “**Prop Source**” Port
 
-You can also open this folder directly using the “**Open Music Folder**” button in the “**Music Player**” Asset.
+You can find this folder by selecting **Menu → Open Data Folder** and opening the `Props` folder.
 
 ### Scenes
 
@@ -261,7 +262,7 @@ This folder is used to store the **video** files.
 
 **Supported Formats:** Video formats
 
-You can use the image files in the following scenarios:
+You can use the video files in the following scenarios:
 - “[**Screen**](/docs/assets/screen)” Asset – “**Video Source**” Option (“**Content Type**” should be “**Video**”)
 
 ## Additional Subfolders


### PR DESCRIPTION
## Summary

- Fix broken internal links and incorrect anchors across the English documentation.
- Replace the invalid Streamer.bot link with its official website.
- Update links that referenced removed or relocated documentation pages.
- Correct invalid Docusaurus admonition directives.
- Fix incorrect node names and typographical errors in blueprint tutorials.
- Clarify inaccurate instructions and descriptions in the data folder guide.

## Details

This updates links to the current character mod, onboarding, watcher, and data input documentation. It also corrects several content issues, including the `Set Character Bone Scale` node name, a misspelled `Transform` label, incorrectly merged list entries, and inaccurate folder and file-type descriptions.

These changes are intentionally kept separate from #123 and modify only the English documentation.

## Validation

- `yarn typecheck`
- `yarn docusaurus build --locale en`
- Verified that the English build completes without broken-link, broken-anchor, or invalid-directive warnings.
- Verified that the corrected Streamer.bot URL is reachable.